### PR TITLE
Mobile Alternative

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -111,9 +111,11 @@ export default {
 <style scoped>
 .twitter:hover{
     background-color: white;
+    border-radius: 10px;
 }
 .instagram:hover{
     background-color: white;
+    border-radius: 10px;
 }
 .social{
     padding: 5px;

--- a/src/App.vue
+++ b/src/App.vue
@@ -33,12 +33,37 @@
     <q-page-container>
       <router-view></router-view>
       
-      <q-page-sticky position="bottom-right" :offset="[8, 18]">
+      <q-page-sticky position="bottom-right" :offset="[8, 18]" class="gt-xs">
+        <q-btn round flat class="" :style="{ width: toTopWidth + 'vw' }">
+          <q-img @click="toTop" src="./assets/PAGE-TOP.png"></q-img>   
+        </q-btn>
+      </q-page-sticky>
+
+      <q-page-sticky position="bottom-right" :offset="[5, 45]" class="lt-sm">
         <q-btn round flat class="" :style="{ width: toTopWidth + 'vw' }">
           <q-img @click="toTop" src="./assets/PAGE-TOP.png"></q-img>   
         </q-btn>
       </q-page-sticky>
       
+      <q-page-sticky position="bottom" :offset="[0]">
+        <q-list class="lt-sm sns">
+            <div class="row lt-md">
+                <div class="col-3"></div>
+                <div class="col column items-center q-mt-sm q-mb-sm">
+                    <a href="https://twitter.com/salvia__mama" target="_blank">
+                        <q-img :src="tsrc" width="30px"></q-img>
+                    </a>
+                </div>
+                <div class="col column items-center q-mt-sm q-mb-sm">
+                    <a href="https://www.instagram.com/salvia_mama/" target="_blank">
+                        <q-img :src="instasrc" width="25px"></q-img>
+                    </a>
+                </div>
+                <div class="col-3"></div>
+            </div>
+        </q-list>
+      </q-page-sticky>
+
     </q-page-container>
 
     <the-footer></the-footer>
@@ -120,5 +145,9 @@ export default {
 .social{
     padding: 5px;
     border-radius: 5px;
+}
+.sns{
+  background-color: rgb(205, 75, 128);
+  min-width: 500px;
 }
 </style>

--- a/src/components/Contact.vue
+++ b/src/components/Contact.vue
@@ -234,6 +234,8 @@
     </q-form>
 
 </div>
+
+<div class="row lt-sm" style="height: 50px"></div>
 </template>
 
 <script>

--- a/src/components/base/WrittersCard.vue
+++ b/src/components/base/WrittersCard.vue
@@ -124,6 +124,7 @@ export default {
                 this.badgePad = 1;
                 this.badgeFontSize = 1;
                 this.avatarWidth = 90;
+                this.lineHeight = 2;
                 this.nameSize = 1;
                 this.desSize = 1;
                 this.linkSize = 1;
@@ -131,6 +132,7 @@ export default {
                 this.badgePad = 1;
                 this.badgeFontSize = 1;
                 this.avatarWidth = 90;
+                this.lineHeight = 2;
                 this.nameSize = 1;
                 this.desSize = 1;
                 this.linkSize = 1;
@@ -138,6 +140,7 @@ export default {
                 this.badgePad = 1;
                 this.badgeFontSize = 1;
                 this.avatarWidth = 90;
+                this.lineHeight = 2;
                 this.nameSize = 1;
                 this.desSize = 1;
                 this.linkSize = 1;

--- a/src/components/faq/Q&ACard.vue
+++ b/src/components/faq/Q&ACard.vue
@@ -65,7 +65,7 @@ export default {
                 this.detailFontSize = 3
             } else {
                 this.leadFontSize = 6
-                this.detailFontSize = 3.5
+                this.detailFontSize = 4 
             }
         },
     },

--- a/src/components/intro/Pros.vue
+++ b/src/components/intro/Pros.vue
@@ -125,18 +125,24 @@ export default {
             if (val > 1600) {
                 this.pointWidth = 100;
                 this.arrowPad = 1;
+                this.arrowWidth = 90;
                 this.textFontSize = 1.7;
             } else if (val > 1400) {
                 this.pointWidth = 100;
                 this.arrowPad = 1;
+                this.arrowWidth = 90;
                 this.textFontSize = 1.7;
             } else if(val > 1200){ 
                 this.pointWidth = 100;
+                this.arrowWidth = 90
+                this.arrowWidth = 90;
                 this.arrowPad = 1;
                 this.textFontSize = 1.7;
             } else if(val > 1000) {
                 this.pointWidth = 100;
+                this.arrowWidth = 90;
                 this.arrowPad = 1;
+                
                 this.textFontSize = 2;
             } else if(val > 500){
                 this.pointWidth = 100;

--- a/src/components/price/Others.vue
+++ b/src/components/price/Others.vue
@@ -13,7 +13,7 @@
                 以下の商品は取り扱い不可です。
             </div>
             <div class="row q-mt-sm q-gutter-sm">
-                <div class="col-xl-3 col-lg-3 col-md-3 col-sm-3 col-xs-5 grow">
+                <div class="col-xl-3 col-lg-3 col-md-3 col-sm-3 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -25,7 +25,7 @@
                        </q-card-section>
                     </q-card>
                 </div>                
-                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-5 grow">
+                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -37,7 +37,7 @@
                        </q-card-section>
                     </q-card>
                 </div>
-                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-5 grow">
+                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -49,7 +49,7 @@
                        </q-card-section>
                     </q-card>
                 </div>
-                <div class="col-xl-3 col-lg-4 col-md-4 col-sm-4 col-xs-5 grow">
+                <div class="col-xl-3 col-lg-4 col-md-4 col-sm-4 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -62,7 +62,7 @@
                     </q-card>
                 </div>
             
-               <div class="col-xl-3 col-lg-3 col-md-3 col-sm-3 col-xs-5 grow">
+               <div class="col-xl-3 col-lg-3 col-md-3 col-sm-3 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -74,7 +74,7 @@
                        </q-card-section>
                     </q-card>
                 </div>                
-                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-5 grow">
+                <div class="col-xl-2 col-lg-2 col-md-3 col-sm-3 col-xs-12 grow">
                     <q-card bordered>
                        <q-card-section>
                            <span>                       
@@ -86,7 +86,7 @@
                        </q-card-section>
                     </q-card>
                 </div>
-                <div class="col-6 grow">
+                <div class="col-xl-6 col-lg-6 col-md-6 col-sm-6 col-xs-12 grow">
                     <q-card bordered class="">
                        <q-card-section>
                            <span>                       
@@ -148,8 +148,8 @@ export default {
                 this.crossWidth = 3.5
             } else {
                 this.tableWidth = 90
-                this.plainTextSize = 2.9
-                this.crossWidth = 5
+                this.plainTextSize = 4.5
+                this.crossWidth = 6.5
             }
         },
     },

--- a/src/components/price/Others.vue
+++ b/src/components/price/Others.vue
@@ -132,11 +132,11 @@ export default {
                 this.crossWidth = 3
             } else if (val > 1400) {
                 this.tableWidth = 75
-                this.plainTextSize = 1.3
+                this.plainTextSize = 1.4
                 this.crossWidth = 3
             } else if(val > 1200){ 
                 this.tableWidth = 75
-                this.plainTextSize = 1.3
+                this.plainTextSize = 1.6
                 this.crossWidth = 3
             } else if(val > 1000) {
                 this.tableWidth = 85

--- a/src/components/price/PriceList.vue
+++ b/src/components/price/PriceList.vue
@@ -3,12 +3,12 @@
         <div class="row q-mb-xl">
             <base-badge :label="'価格'" :color="'rgb(150, 131, 229)'" :width="'80%'"></base-badge>
         </div>
-        <div class="row up-des plain-text" :style="{ fontSize: plainTextSize + 'vw' }">
+        <div class="row up-des stand-out-text" :style="{ fontSize: plainTextSize + 'vw' }">
             <div class="col column items-center">
                 レポラマ用の商品（サンプル）はください。
             </div>
         </div>
-        <div class="row up-des q-pb-lg plain-text" :style="{ fontSize: plainTextSize + 'vw' }">
+        <div class="row up-des q-pb-lg stand-out-text" :style="{ fontSize: plainTextSize + 'vw' }">
             <div class="col column items-center">
                 その代わり安価で「レポラマ」を提供します。
             </div>

--- a/src/layouts/TheFooter.vue
+++ b/src/layouts/TheFooter.vue
@@ -1,21 +1,6 @@
 <template>
     <q-footer class="bg-white text-grey footer" :style="{ heigth: footerHeight + 'px' }">
 
-        <q-list style="min-width: 300px" class="lt-sm q-pt-md q-pb-md bg-grey-3 sns">
-            <div class="row lt-md">
-                <div class="col-6 column items-center">
-                    <a href="https://twitter.com/salvia__mama" target="_blank">
-                        <q-img src="../assets/twitter-logo-blue.png" width="37px"></q-img>
-                    </a>
-                </div>
-                <div class="col-6 column items-center">
-                    <a href="https://www.instagram.com/salvia_mama/" target="_blank">
-                        <q-img src="../assets/instagram-logo.png" width="33px"></q-img>
-                    </a>
-                </div>
-            </div>
-        </q-list>
-
         <div class="row">
             <div class="col-xl-3 col-lg-3 col-md-3 col-sm-3 col-xs-5">
                 <div class="main-menu" :style="{ fontSize: mainFontSize + 'vw' }">About us</div>
@@ -111,9 +96,6 @@ export default {
 <style scoped>
 .footer{
     border-top: solid 1px rgb(205, 75, 128);
-}
-.sns{
-    border-bottom: solid 1px rgb(205, 75, 128);
 }
 .main-menu{
     margin: 1.5vw 0 0vw 2.5vw;


### PR DESCRIPTION
This is an alternative look of mobile mode.
Here are some differences: 

1 SNS position:
Previous:
SNS logos stay over footer. Reveal only scrolled reach footer.
![image](https://user-images.githubusercontent.com/74291680/132813453-d5c68b49-35b1-4449-995f-6a05be89372d.png)

Alternative: 
SNS logos stay as a sticky element. Always display at the bottom of the page.
![image](https://user-images.githubusercontent.com/74291680/132813348-9b84128d-c126-4c1f-a3cb-d6e6a35880aa.png)

2 NG商品一覧:
Previous:
Small text size allows multiple badges in one row. 
![image](https://user-images.githubusercontent.com/74291680/132813727-cbd8c48e-733d-496a-87da-3a59101485f6.png)

Alternative:
Larger text size. Force to have only one badge per row.
![image](https://user-images.githubusercontent.com/74291680/132813831-4f0aa4c2-c87a-4046-a9e6-c28cbac85da8.png)

3 よくある質問:
Previous: 
Small text size. Has good looking text alignment.
![image](https://user-images.githubusercontent.com/74291680/132814113-1ac5bd03-c62e-476a-8e3a-7efa58aed3d6.png)

Alternative: 
Larger text size. Increase readability.
![image](https://user-images.githubusercontent.com/74291680/132814034-50b3f893-ba62-49b9-8b03-596e2e85cfbc.png)
